### PR TITLE
Use LX/LM unit instead of LUX

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ All of the sensors (not current_consumption) require additional_information to b
 --------|-----|-----------|---------|
 | temperature | °C | 0 |    |
 | device_temp | °C | 0 |    |
-| illuminance | lux | 0 |    |
+| illuminance | lx | 0 |    |
 | humidity | % | 0 |    |
 | total_consumption | kWh | 2 |  1000 |
 | total_returned | kWh | 2 |  1000  |

--- a/custom_components/shelly/const.py
+++ b/custom_components/shelly/const.py
@@ -61,7 +61,7 @@ DEFAULT_SETTINGS = \
     'default' : {},
     'temperature' : {CONF_UNIT:'°C'},
     'device_temp' : {CONF_UNIT:'°C'},
-    'illuminance' : {CONF_UNIT:'lux'},
+    'illuminance' : {CONF_UNIT:'lx'},
     'humidity' : {CONF_UNIT:'%'},
     'total_consumption' : {CONF_DECIMALS:2, CONF_DIV:1000, CONF_UNIT:'kWh'},
     'total_returned' : {CONF_DECIMALS:2, CONF_DIV:1000, CONF_UNIT:'kWh'},


### PR DESCRIPTION
to be consistent with the Home Assistant documentation? https://www.home-assistant.io/integrations/sensor/#device-class