### PR TITLE
Fix rssi level in config flow

### DIFF
--- a/custom_components/shelly/translations/en.json
+++ b/custom_components/shelly/translations/en.json
@@ -85,6 +85,7 @@
             "sensors": {
                 "data": {
                     "rssi": "RSSI",
+                    "rssi_level": "RSSI Level",
                     "uptime": "Uptime",
                     "current_consumption": "Current consumption",
                     "total_consumption": "Total consumption",

--- a/custom_components/shelly/translations/es.json
+++ b/custom_components/shelly/translations/es.json
@@ -73,6 +73,7 @@
             "sensors": {
                 "data": {
                     "rssi": "RSSI",
+                    "rssi_level": "RSSI Level",
                     "uptime": "Tiempo de actividad",
                     "current_consumption": "Consumo actual",
                     "total_consumption": "Consumo total",

--- a/custom_components/shelly/translations/fr.json
+++ b/custom_components/shelly/translations/fr.json
@@ -73,6 +73,7 @@
             "sensors": {
                 "data": {
                     "rssi": "RSSI",
+                    "rssi_level": "RSSI Level",
                     "uptime": "Durée de fonctionnement",
                     "current_consumption": "Consommation actuelle",
                     "total_consumption": "Consommation totale",

--- a/custom_components/shelly/translations/it.json
+++ b/custom_components/shelly/translations/it.json
@@ -73,6 +73,7 @@
             "sensors": {
                 "data": {
                     "rssi": "RSSI",
+                    "rssi_level": "RSSI Level",
                     "uptime": "Tempo di funzionamento",
                     "current_consumption": "Consumo corrente",
                     "total_consumption": "Consumo Totale",


### PR DESCRIPTION
When adding a new device, the text "RSSI Level" wasn't displayed for the sensors that can be added. (only an checkbox without text was displayed). 

This PR adds the text back. 