### PR TITLE
Fix #659: Invalid entity ID since Home Assistant 2022.03.0

### DIFF
--- a/custom_components/shelly/binary_sensor.py
+++ b/custom_components/shelly/binary_sensor.py
@@ -65,7 +65,7 @@ class ShellySwitch(ShellyDevice, BinarySensorEntity):
         """Initialize an ShellySwitch."""
         ShellyDevice.__init__(self, dev, instance)
         self._unique_id += "_switch"
-        self.entity_id += "_switch"
+        self.entity_id = "switch" + self.entity_id + "_switch"
         self._state = None
         self._click_delay = 700
         self._last_state_change = 0
@@ -145,7 +145,7 @@ class ShellyBinarySensor(ShellyDevice, BinarySensorEntity):
         self._sensor_cfg = SENSOR_TYPES_CFG[SENSOR_TYPE_DEFAULT]
         ShellyDevice.__init__(self, dev, instance)
         self._unique_id += "_" + sensor_name
-        self.entity_id += "_" + sensor_name
+        self.entity_id = "switch" + self.entity_id + "_" + sensor_name
         self._sensor_type = sensor_type
         self._sensor_name = sensor_name
         #self._battery = None

--- a/custom_components/shelly/binary_sensor.py
+++ b/custom_components/shelly/binary_sensor.py
@@ -65,7 +65,7 @@ class ShellySwitch(ShellyDevice, BinarySensorEntity):
         """Initialize an ShellySwitch."""
         ShellyDevice.__init__(self, dev, instance)
         self._unique_id += "_switch"
-        self.entity_id = "switch" + self.entity_id + "_switch"
+        self.entity_id = "binary_sensor" + self.entity_id + "_switch"
         self._state = None
         self._click_delay = 700
         self._last_state_change = 0
@@ -145,7 +145,7 @@ class ShellyBinarySensor(ShellyDevice, BinarySensorEntity):
         self._sensor_cfg = SENSOR_TYPES_CFG[SENSOR_TYPE_DEFAULT]
         ShellyDevice.__init__(self, dev, instance)
         self._unique_id += "_" + sensor_name
-        self.entity_id = "switch" + self.entity_id + "_" + sensor_name
+        self.entity_id = "binary_sensor" + self.entity_id + "_" + sensor_name
         self._sensor_type = sensor_type
         self._sensor_name = sensor_name
         #self._battery = None

--- a/custom_components/shelly/cover.py
+++ b/custom_components/shelly/cover.py
@@ -43,6 +43,7 @@ class ShellyCover(ShellyDevice, CoverEntity):
     def __init__(self, dev, instance):
         """Initialize the cover."""
         ShellyDevice.__init__(self, dev, instance)
+        self.entity_id = "cover" + self.entity_id
         self._position = None
         self._last_direction = None
         self._motion_state = None

--- a/custom_components/shelly/light.py
+++ b/custom_components/shelly/light.py
@@ -82,6 +82,7 @@ class ShellyLightRelay(ShellyDevice, LightEntity):
     def __init__(self, dev, instance):
         """Initialize an ShellyLightRelay."""
         ShellyDevice.__init__(self, dev, instance)
+        self.entity_id = "light" + self.entity_id
         self._state = None
         self._master_unit = True
         self.update()
@@ -111,6 +112,7 @@ class ShellyDimmer(ShellyDevice, LightEntity):
     def __init__(self, dev, instance):
         """Initialize an ShellyDimmer."""
         ShellyDevice.__init__(self, dev, instance)
+        self.entity_id = "light" + self.entity_id
         self._state = None
         self._brightness = None
         self._color_temp = None
@@ -219,6 +221,7 @@ class ShellyRGB(ShellyDevice, LightEntity):
     def __init__(self, dev, instance):
         """Initialize an ShellyLightRelay."""
         ShellyDevice.__init__(self, dev, instance)
+        self.entity_id = "light" + self.entity_id
         self._state = None
         self._brightness = None
         self._white_value = None

--- a/custom_components/shelly/sensor.py
+++ b/custom_components/shelly/sensor.py
@@ -62,7 +62,7 @@ class ShellySensor(ShellyDevice):
         self._sensor_cfg = SENSOR_TYPES_CFG[SENSOR_TYPE_DEFAULT]
         ShellyDevice.__init__(self, dev, instance)
         self._unique_id += "_" + sensor_name
-        self.entity_id += "_" + sensor_name
+        self.entity_id = "sensor" + self.entity_id + "_" + sensor_name
         self._sensor_type = sensor_type
         self._sensor_name = sensor_name
         self._battery = None

--- a/custom_components/shelly/switch.py
+++ b/custom_components/shelly/switch.py
@@ -60,6 +60,7 @@ class ShellySwitch(ShellyDevice, SwitchEntity):
     def __init__(self, dev, instance):
         """Initialize an ShellySwitch."""
         ShellyDevice.__init__(self, dev, instance)
+        self.entity_id = "switch" + self.entity_id
         self._state = None
         self._master_unit = True
         self.update()


### PR DESCRIPTION
Home Assistant 2022.03.0 introduced following breaking change for this repo;

> Helper: split_entity_id()
split_entity_id will now raise a ValueError if the passed value does not follow the basic entity ID format (.).
>
> Previously it could return a list with a single item.
>
> ([@balloob](https://github.com/balloob) - https://github.com/home-assistant/core/pull/66835)

This change results in a bug where many entities are not loaded because of invalid format returned from [ShellyDevice.__init__](https://github.com/StyraHem/ShellyForHASS/blob/master/custom_components/shelly/device.py#L18) function. As per the new Home Assistant version, entity_id always needs to include platform.

This was already done properly in _some_ places, like for example [ShellyVersion](https://github.com/StyraHem/ShellyForHASS/blob/master/custom_components/shelly/sensor.py#L196) sensor, where platform is added. However, this does not happen in all the places, which this PR now fixes.

**This PR adds platform to every entity_id similarly to how it was done in [ShellyVersion](https://github.com/StyraHem/ShellyForHASS/blob/master/custom_components/shelly/sensor.py#L196) class.**

_Warning:_ I use only binary_sensor, switch and sensor entities from Shelly. I could not test light and cover platforms.