### PR TITLE
Fix shelly/config not loading

### DIFF
--- a/custom_components/shelly/ws_handler.py
+++ b/custom_components/shelly/ws_handler.py
@@ -20,14 +20,15 @@ async def setup_ws(instance):
     websocket_api.async_register_command(hass, shelly_convert)
 
 @websocket_api.async_response
-@websocket_api.websocket_command({vol.Required("type"): "s4h/get_config", vol.Required("language"): cv.string})
+@websocket_api.websocket_command({vol.Required("type"): "s4h/get_config", vol.Required("language", default="en"): cv.string})
 async def shelly_get_config(hass, connection, msg):
     resources = await async_get_translations(
-        hass,
-        msg["language"],
-        'frontend',
-        'shelly'
+        hass=hass,
+        language=msg["language"],
+        category='frontend',
+        integrations=['shelly'],
     )
+
     #print("GET CONFIG*****************")
     """Handle get config command."""
     content = {}


### PR DESCRIPTION
Ensure `language` got a default value if not defined in the config, and make the `integrations` argument `Iterable` per the interface requirement

This makes `shell/config` load correctly for me on most recent stable `Home Assistant Core 2022.6.0`

Prior i got exceptions about `integrations` must be `Iterable or None` as per [the HA code](https://github.com/home-assistant/core/blob/master/homeassistant/helpers/translation.py#L285-L291)

