### PR TITLE
Fix bug around white values

### DIFF
--- a/custom_components/shelly/light.py
+++ b/custom_components/shelly/light.py
@@ -11,9 +11,7 @@ from homeassistant.const import (
 )
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT, ATTR_HS_COLOR, 
-    ATTR_WHITE_VALUE,
     SUPPORT_BRIGHTNESS, SUPPORT_COLOR, SUPPORT_COLOR_TEMP, SUPPORT_EFFECT,
-    SUPPORT_WHITE_VALUE,
 )
 from functools import partial
 from homeassistant.helpers import config_validation as cv, entity_platform, service
@@ -286,10 +284,6 @@ class ShellyRGB(ShellyDevice, LightEntity):
         if ATTR_BRIGHTNESS in kwargs:
             brightness = round(kwargs[ATTR_BRIGHTNESS] / 2.55)
             self._brightness = brightness
-
-        if ATTR_WHITE_VALUE in kwargs:
-            white_value = int(kwargs[ATTR_WHITE_VALUE])
-            self._white_value = white_value
 
         if ATTR_HS_COLOR in kwargs:
             red, green, blue = \


### PR DESCRIPTION
Very crude quick fix to address #713 
Doesn't work with RGBW or RGB lights but will at least allow your regular shelly switches and dimmers to work.

Further work required for RGB