### PR TITLE
Update paho-mqtt

### DIFF
--- a/custom_components/shelly/manifest.json
+++ b/custom_components/shelly/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/StyraHem/ShellyForHASS/blob/master/README.md",
   "dependencies": ["zeroconf"],
   "codeowners": ["@hakana","@StyraHem"],
-  "requirements": ["pyShelly==1.0.4", "paho-mqtt==1.6.1", "websocket-client"],
+  "requirements": ["pyShelly==1.0.4", "paho-mqtt==2.0.1", "websocket-client"],
   "iot_class": "local_push"
 }


### PR DESCRIPTION
With homeassistant 2025.3.0 ShellyForHass cannot start because requirement for paho-mqtt version 1.6.1 is failing.